### PR TITLE
Added casters in srdf

### DIFF
--- a/fetch_moveit_config/config/fetch.srdf
+++ b/fetch_moveit_config/config/fetch.srdf
@@ -36,6 +36,10 @@
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="gripper" parent_link="wrist_roll_link" group="gripper" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base_link" link2="fl_caster_link" reason="Default" />
+    <disable_collisions link1="base_link" link2="fr_caster_link" reason="Default" />
+    <disable_collisions link1="base_link" link2="br_caster_link" reason="Default" />
+    <disable_collisions link1="base_link" link2="bl_caster_link" reason="Default" />
     <disable_collisions link1="base_link" link2="bellows_link" reason="Default" />
     <disable_collisions link1="base_link" link2="bellows_link2" reason="Default" />
     <disable_collisions link1="base_link" link2="estop_link" reason="Adjacent" />


### PR DESCRIPTION
In the gazebo urdf model (.xacro) they added some casters in the base to improve the stability. However they did not update the srdf. When the gazebo urdf model is used and full collision checking is performed a collision was allways detected between the casters and the base_link. This PR fixes that. The original urdf file under fetch descriprion does not include the casters so this will result in a warning but it should not affect anyone. I will merge this in a few days if there are no objections